### PR TITLE
atom parsing, now using the apache abdera library 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,11 @@
             <artifactId>httpclient</artifactId>
             <version>4.5</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.abdera</groupId>
+            <artifactId>abdera-parser</artifactId>
+            <version>1.1.3</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/java/nl/knaw/dans/easy/sword2examples/Common.java
+++ b/src/main/java/nl/knaw/dans/easy/sword2examples/Common.java
@@ -15,6 +15,13 @@
  */
 package nl.knaw.dans.easy.sword2examples;
 
+import org.apache.abdera.Abdera;
+import org.apache.abdera.i18n.iri.IRI;
+import org.apache.abdera.model.Category;
+import org.apache.abdera.model.Document;
+import org.apache.abdera.model.Entry;
+import org.apache.abdera.model.Feed;
+import org.apache.abdera.parser.Parser;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
@@ -41,6 +48,7 @@ import java.io.InputStream;
 import java.io.StringReader;
 import java.net.URI;
 import java.security.DigestInputStream;
+import java.util.List;
 
 public class Common {
     static final String BAGIT_URI = "http://purl.org/net/sword/package/BagIt";
@@ -59,44 +67,49 @@ public class Common {
         return new String(bos.toByteArray(), "UTF-8");
     }
 
-    /**
-     * Returns the result of evaluating the XPath expression <code>expr</code> on the XML code in the string <code>xml</code>
-     *
-     * @param xml
-     *        the XML to query
-     * @param expr
-     *        the XPath expression
-     * @return the result as a string
-     * @throws Exception
-     */
-    public static String getStringFromXml(String xml, String expr) throws Exception {
-        InputSource xmlSource = new InputSource(new StringReader(xml));
-        XPathFactory xpathFactory = XPathFactory.newInstance();
-        XPath xpath = xpathFactory.newXPath();
-        return (String) xpath.evaluate(expr, xmlSource, XPathConstants.STRING);
+    public static Entry parseEntry(String text) {
+        Abdera abdera = Abdera.getInstance();
+        Parser parser = abdera.getParser();
+        Document<Entry> receipt = parser.parse(new StringReader(text));
+        return receipt.getRoot();
     }
 
-    static void trackDeposit(CloseableHttpClient http, URI statIri) throws Exception {
+    public static Feed parseFeed(String text) {
+        Abdera abdera = Abdera.getInstance();
+        Parser parser = abdera.getParser();
+        Document<Feed> receipt = parser.parse(new StringReader(text));
+        return receipt.getRoot();
+    }
+
+    static void trackDeposit(CloseableHttpClient http, IRI statIri) throws Exception {
         CloseableHttpResponse response;
         String bodyText;
         System.out.println("Start polling Stat-IRI for the current status of the deposit, waiting 10 seconds before every request ...");
-        String state = null;
+        String stateTerm = null;
+        String stateText = null;
         while (true) {
             Thread.sleep(10000);
             System.out.print("Checking deposit status ... ");
-            response = http.execute(new HttpGet(statIri));
+            response = http.execute(new HttpGet(statIri.toURI()));
             bodyText = readEntityAsString(response.getEntity());
-            state = getStringFromXml(bodyText,
-                    "//*[local-name() = 'category' and @scheme = 'http://purl.org/net/sword/terms/state' and @label = 'State']/@term");
-            System.out.println(state);
-            if (state.equals("INVALID") || state.equals("REJECTED") || state.equals("FAILED")) {
+            Feed statement = parseFeed(bodyText);
+            List<Category> states = statement.getCategories("http://purl.org/net/sword/terms/state");
+            if (states.size() < 1) {
+                System.err.println("ERROR: NO STATE FOUND");
+                System.exit(1);
+            } else if (states.size() > 1) {
+                System.err.println("ERROR: FOUND TOO MANY STATES (" + states.size() + "). CAN ONLY HANDLE ONE");
+                System.exit(1);
+            }
+            stateTerm = states.get(0).getTerm();
+            stateText = states.get(0).getText();
+            System.out.println(stateTerm);
+            if (stateTerm.equals("INVALID") || stateTerm.equals("REJECTED") || stateTerm.equals("FAILED")) {
                 System.err.println("FAILURE. Complete statement follows:");
                 System.err.println(bodyText);
                 System.exit(3);
-            } else if (state.equals("ARCHIVED")) {
-                System.out.println("SUCCESS. Deposit has been archived at: "
-                        + getStringFromXml(bodyText,
-                                "//*[local-name() = 'category' and @scheme = 'http://purl.org/net/sword/terms/state' and @label = 'State']"));
+            } else if (stateTerm.equals("ARCHIVED")) {
+                System.out.println("SUCCESS. Deposit has been archived at: " + stateText);
                 System.out.println("Complete statement follows:");
                 System.out.println(bodyText);
                 System.exit(0);
@@ -118,11 +131,11 @@ public class Common {
         return HttpClients.custom().setDefaultCredentialsProvider(credsProv).build();
     }
 
-    public static CloseableHttpResponse sendChunk(DigestInputStream dis, int size, String method, URI iri, String filename, String mimeType, CloseableHttpClient http, boolean inProgress) throws Exception {
+    public static CloseableHttpResponse sendChunk(DigestInputStream dis, int size, String method, IRI iri, String filename, String mimeType, CloseableHttpClient http, boolean inProgress) throws Exception {
         // System.out.println(String.format("Sending chunk to %s, filename = %s, chunk size = %d, MIME-Type = %s, In-Progress = %s ... ", iri.toString(), filename, size, mimeType, Boolean.toString(inProgress)));
         byte[] chunk = readChunk(dis, size);
         String md5 = new String(Hex.encodeHex(dis.getMessageDigest().digest()));
-        HttpUriRequest request = RequestBuilder.create(method).setUri(iri).setConfig(RequestConfig.custom()
+        HttpUriRequest request = RequestBuilder.create(method).setUri(iri.toURI()).setConfig(RequestConfig.custom()
         /*
          * When using an HTTPS-connection this EXPECT-CONTINUE must be enabled, otherwise buffer overflow may follow
          */

--- a/src/main/java/nl/knaw/dans/easy/sword2examples/Common.java
+++ b/src/main/java/nl/knaw/dans/easy/sword2examples/Common.java
@@ -37,11 +37,7 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.xml.sax.InputSource;
 
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathFactory;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/nl/knaw/dans/easy/sword2examples/Common.java
+++ b/src/main/java/nl/knaw/dans/easy/sword2examples/Common.java
@@ -127,7 +127,7 @@ public class Common {
         String md5 = new String(Hex.encodeHex(dis.getMessageDigest().digest()));
         HttpUriRequest request = RequestBuilder.create(method).setUri(uri).setConfig(RequestConfig.custom()
         /*
-         * When using an HTTPS-connection this EXPECT-CONTINUE must be enabled, otherwise buffer overflow may follow
+         * When using an HTTPS-connection EXPECT-CONTINUE must be enabled, otherwise buffer overflow may follow
          */
                 .setExpectContinueEnabled(true).build()) //
                     .addHeader("Content-Disposition", String.format("attachment; filename=%s", filename)) //

--- a/src/main/java/nl/knaw/dans/easy/sword2examples/Common.java
+++ b/src/main/java/nl/knaw/dans/easy/sword2examples/Common.java
@@ -69,14 +69,14 @@ public class Common {
         return receipt.getRoot();
     }
 
-    static void trackDeposit(CloseableHttpClient http, URI statIri) throws Exception {
+    static void trackDeposit(CloseableHttpClient http, URI statUri) throws Exception {
         CloseableHttpResponse response;
         String bodyText;
         System.out.println("Start polling Stat-IRI for the current status of the deposit, waiting 10 seconds before every request ...");
         while (true) {
             Thread.sleep(10000);
             System.out.print("Checking deposit status ... ");
-            response = http.execute(new HttpGet(statIri));
+            response = http.execute(new HttpGet(statUri));
             bodyText = readEntityAsString(response.getEntity());
             Feed statement = parse(bodyText);
             List<Category> states = statement.getCategories("http://purl.org/net/sword/terms/state");
@@ -115,17 +115,17 @@ public class Common {
         return bos.toByteArray();
     }
 
-    public static CloseableHttpClient createHttpClient(URI iri, String uid, String pw) {
+    public static CloseableHttpClient createHttpClient(URI uri, String uid, String pw) {
         BasicCredentialsProvider credsProv = new BasicCredentialsProvider();
-        credsProv.setCredentials(new AuthScope(iri.getHost(), iri.getPort()), new UsernamePasswordCredentials(uid, pw));
+        credsProv.setCredentials(new AuthScope(uri.getHost(), uri.getPort()), new UsernamePasswordCredentials(uid, pw));
         return HttpClients.custom().setDefaultCredentialsProvider(credsProv).build();
     }
 
-    public static CloseableHttpResponse sendChunk(DigestInputStream dis, int size, String method, URI iri, String filename, String mimeType, CloseableHttpClient http, boolean inProgress) throws Exception {
-        // System.out.println(String.format("Sending chunk to %s, filename = %s, chunk size = %d, MIME-Type = %s, In-Progress = %s ... ", iri.toString(), filename, size, mimeType, Boolean.toString(inProgress)));
+    public static CloseableHttpResponse sendChunk(DigestInputStream dis, int size, String method, URI uri, String filename, String mimeType, CloseableHttpClient http, boolean inProgress) throws Exception {
+        // System.out.println(String.format("Sending chunk to %s, filename = %s, chunk size = %d, MIME-Type = %s, In-Progress = %s ... ", uri.toString(), filename, size, mimeType, Boolean.toString(inProgress)));
         byte[] chunk = readChunk(dis, size);
         String md5 = new String(Hex.encodeHex(dis.getMessageDigest().digest()));
-        HttpUriRequest request = RequestBuilder.create(method).setUri(iri).setConfig(RequestConfig.custom()
+        HttpUriRequest request = RequestBuilder.create(method).setUri(uri).setConfig(RequestConfig.custom()
         /*
          * When using an HTTPS-connection this EXPECT-CONTINUE must be enabled, otherwise buffer overflow may follow
          */

--- a/src/main/java/nl/knaw/dans/easy/sword2examples/ContinuedDeposit.java
+++ b/src/main/java/nl/knaw/dans/easy/sword2examples/ContinuedDeposit.java
@@ -15,12 +15,14 @@
  */
 package nl.knaw.dans.easy.sword2examples;
 
+import org.apache.abdera.i18n.iri.IRI;
+import org.apache.abdera.model.Entry;
+import org.apache.abdera.model.Link;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.impl.client.CloseableHttpClient;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.net.URI;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 
@@ -33,7 +35,7 @@ public class ContinuedDeposit {
 
         // 0. Read command line arguments
         final String bagFileName = args[0];
-        final URI colIri = new URI(args[1]);
+        final IRI colIri = new IRI(args[1]);
         final String uid = args[2];
         final String pw = args[3];
         final int chunkSize = Integer.parseInt(args[4]);
@@ -45,7 +47,7 @@ public class ContinuedDeposit {
         DigestInputStream dis = new DigestInputStream(fis, md);
 
         // 2. Post first chunk bag to Col-IRI
-        CloseableHttpClient http = Common.createHttpClient(colIri, uid, pw);
+        CloseableHttpClient http = Common.createHttpClient(colIri.toURI(), uid, pw);
         CloseableHttpResponse response = Common.sendChunk(dis, chunkSize, "POST", colIri,  "bag.zip.1", "application/octet-stream", http, chunkSize < bag.length());
 
 
@@ -60,7 +62,9 @@ public class ContinuedDeposit {
         System.out.println("SUCCESS. Deposit receipt follows:");
         System.out.println(bodyText);
 
-        URI seIri =  new URI(Common.getStringFromXml(bodyText, "//*[local-name() = 'link' and @rel = 'edit']/@href"));
+        Entry receipt = Common.parseEntry(bodyText);
+        Link seIriLink = receipt.getLink("edit");
+        IRI seIri = seIriLink.getHref();
 
         int remaining = (int) bag.length() - chunkSize;
         int count = 2;
@@ -80,7 +84,9 @@ public class ContinuedDeposit {
 
         // 4. Get the statement URL. This is the URL from which to retrieve the current status of the deposit.
         System.out.println("Retrieving Statement IRI (Stat-IRI) from deposit receipt ...");
-        URI statIri = new URI(Common.getStringFromXml(bodyText, "//*[local-name() = 'link' and @rel = 'http://purl.org/net/sword/terms/statement']/@href"));
+        receipt = Common.parseEntry(bodyText);
+        Link statIriLink = receipt.getLink("http://purl.org/net/sword/terms/statement");
+        IRI statIri = statIriLink.getHref();
         System.out.println("Stat-IRI = " + statIri);
 
         // 5. Check statement every ten seconds (a bit too frantic, but okay for this test). If status changes:

--- a/src/main/java/nl/knaw/dans/easy/sword2examples/ContinuedDeposit.java
+++ b/src/main/java/nl/knaw/dans/easy/sword2examples/ContinuedDeposit.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.easy.sword2examples;
 
+import org.apache.abdera.i18n.iri.IRI;
 import org.apache.abdera.model.Entry;
 import org.apache.abdera.model.Link;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -35,7 +36,7 @@ public class ContinuedDeposit {
 
         // 0. Read command line arguments
         final String bagFileName = args[0];
-        final URI colIri = new URI(args[1]);
+        final IRI colIri = new IRI(args[1]);
         final String uid = args[2];
         final String pw = args[3];
         final int chunkSize = Integer.parseInt(args[4]);
@@ -47,8 +48,8 @@ public class ContinuedDeposit {
         DigestInputStream dis = new DigestInputStream(fis, md);
 
         // 2. Post first chunk bag to Col-IRI
-        CloseableHttpClient http = Common.createHttpClient(colIri, uid, pw);
-        CloseableHttpResponse response = Common.sendChunk(dis, chunkSize, "POST", colIri,  "bag.zip.1", "application/octet-stream", http, chunkSize < bag.length());
+        CloseableHttpClient http = Common.createHttpClient(colIri.toURI(), uid, pw);
+        CloseableHttpResponse response = Common.sendChunk(dis, chunkSize, "POST", colIri.toURI(),  "bag.zip.1", "application/octet-stream", http, chunkSize < bag.length());
 
 
         // 3. Check the response. If transfer corrupt (MD5 doesn't check out), report and exit.
@@ -86,11 +87,11 @@ public class ContinuedDeposit {
         System.out.println("Retrieving Statement IRI (Stat-IRI) from deposit receipt ...");
         receipt = Common.parse(bodyText);
         Link statIriLink = receipt.getLink("http://purl.org/net/sword/terms/statement");
-        URI statIri = statIriLink.getHref().toURI();
+        IRI statIri = statIriLink.getHref();
         System.out.println("Stat-IRI = " + statIri);
 
         // 5. Check statement every ten seconds (a bit too frantic, but okay for this test). If status changes:
         // report new status. If status is an error (INVALID, REJECTED, FAILED) or ARCHIVED: exit.
-        Common.trackDeposit(http, statIri);
+        Common.trackDeposit(http, statIri.toURI());
     }
 }

--- a/src/main/java/nl/knaw/dans/easy/sword2examples/SimpleDeposit.java
+++ b/src/main/java/nl/knaw/dans/easy/sword2examples/SimpleDeposit.java
@@ -15,11 +15,14 @@
  */
 package nl.knaw.dans.easy.sword2examples;
 
+import org.apache.abdera.i18n.iri.IRI;
+import org.apache.abdera.model.Entry;
+import org.apache.abdera.model.Link;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.impl.client.CloseableHttpClient;
 
-import java.io.*;
-import java.net.URI;
+import java.io.File;
+import java.io.FileInputStream;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 
@@ -39,7 +42,7 @@ public class SimpleDeposit {
 
         // 0. Read command line arguments
         final String bagFileName = args[0];
-        final URI colIri = new URI(args[1]);
+        final IRI colIri = new IRI(args[1]);
         final String uid = args[2];
         final String pw = args[3];
 
@@ -50,7 +53,7 @@ public class SimpleDeposit {
         DigestInputStream dis = new DigestInputStream(fis, md);
 
         // 2. Post entire bag to Col-IRI
-        CloseableHttpClient http = Common.createHttpClient(colIri, uid, pw);
+        CloseableHttpClient http = Common.createHttpClient(colIri.toURI(), uid, pw);
         CloseableHttpResponse response = Common.sendChunk(dis, (int) bag.length(), "POST", colIri, "bag.zip", "application/zip", http, false);
 
         // 3. Check the response. If transfer corrupt (MD5 doesn't check out), report and exit.
@@ -66,7 +69,9 @@ public class SimpleDeposit {
 
         // 4. Get the statement URL. This is the URL from which to retrieve the current status of the deposit.
         System.out.println("Retrieving Statement IRI (Stat-IRI) from deposit receipt ...");
-        URI statIri = new URI(Common.getStringFromXml(bodyText, "//*[local-name() = 'link' and @rel = 'http://purl.org/net/sword/terms/statement']/@href"));
+        Entry receipt = Common.parseEntry(bodyText);
+        Link statLink = receipt.getLink("http://purl.org/net/sword/terms/statement");
+        IRI statIri = statLink.getHref();
         System.out.println("Stat-IRI = " + statIri);
 
         // 5. Check statement every ten seconds (a bit too frantic, but okay for this test). If status changes:

--- a/src/main/java/nl/knaw/dans/easy/sword2examples/SimpleDeposit.java
+++ b/src/main/java/nl/knaw/dans/easy/sword2examples/SimpleDeposit.java
@@ -15,7 +15,6 @@
  */
 package nl.knaw.dans.easy.sword2examples;
 
-import org.apache.abdera.i18n.iri.IRI;
 import org.apache.abdera.model.Entry;
 import org.apache.abdera.model.Link;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -23,6 +22,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.net.URI;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 
@@ -42,7 +42,7 @@ public class SimpleDeposit {
 
         // 0. Read command line arguments
         final String bagFileName = args[0];
-        final IRI colIri = new IRI(args[1]);
+        final URI colIri = new URI(args[1]);
         final String uid = args[2];
         final String pw = args[3];
 
@@ -53,7 +53,7 @@ public class SimpleDeposit {
         DigestInputStream dis = new DigestInputStream(fis, md);
 
         // 2. Post entire bag to Col-IRI
-        CloseableHttpClient http = Common.createHttpClient(colIri.toURI(), uid, pw);
+        CloseableHttpClient http = Common.createHttpClient(colIri, uid, pw);
         CloseableHttpResponse response = Common.sendChunk(dis, (int) bag.length(), "POST", colIri, "bag.zip", "application/zip", http, false);
 
         // 3. Check the response. If transfer corrupt (MD5 doesn't check out), report and exit.
@@ -69,9 +69,9 @@ public class SimpleDeposit {
 
         // 4. Get the statement URL. This is the URL from which to retrieve the current status of the deposit.
         System.out.println("Retrieving Statement IRI (Stat-IRI) from deposit receipt ...");
-        Entry receipt = Common.parseEntry(bodyText);
+        Entry receipt = Common.parse(bodyText);
         Link statLink = receipt.getLink("http://purl.org/net/sword/terms/statement");
-        IRI statIri = statLink.getHref();
+        URI statIri = statLink.getHref().toURI();
         System.out.println("Stat-IRI = " + statIri);
 
         // 5. Check statement every ten seconds (a bit too frantic, but okay for this test). If status changes:

--- a/src/main/java/nl/knaw/dans/easy/sword2examples/SimpleDeposit.java
+++ b/src/main/java/nl/knaw/dans/easy/sword2examples/SimpleDeposit.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.easy.sword2examples;
 
+import org.apache.abdera.i18n.iri.IRI;
 import org.apache.abdera.model.Entry;
 import org.apache.abdera.model.Link;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -42,7 +43,7 @@ public class SimpleDeposit {
 
         // 0. Read command line arguments
         final String bagFileName = args[0];
-        final URI colIri = new URI(args[1]);
+        final IRI colIri = new IRI(args[1]);
         final String uid = args[2];
         final String pw = args[3];
 
@@ -53,8 +54,8 @@ public class SimpleDeposit {
         DigestInputStream dis = new DigestInputStream(fis, md);
 
         // 2. Post entire bag to Col-IRI
-        CloseableHttpClient http = Common.createHttpClient(colIri, uid, pw);
-        CloseableHttpResponse response = Common.sendChunk(dis, (int) bag.length(), "POST", colIri, "bag.zip", "application/zip", http, false);
+        CloseableHttpClient http = Common.createHttpClient(colIri.toURI(), uid, pw);
+        CloseableHttpResponse response = Common.sendChunk(dis, (int) bag.length(), "POST", colIri.toURI(), "bag.zip", "application/zip", http, false);
 
         // 3. Check the response. If transfer corrupt (MD5 doesn't check out), report and exit.
         String bodyText = Common.readEntityAsString(response.getEntity());
@@ -71,12 +72,12 @@ public class SimpleDeposit {
         System.out.println("Retrieving Statement IRI (Stat-IRI) from deposit receipt ...");
         Entry receipt = Common.parse(bodyText);
         Link statLink = receipt.getLink("http://purl.org/net/sword/terms/statement");
-        URI statIri = statLink.getHref().toURI();
+        IRI statIri = statLink.getHref();
         System.out.println("Stat-IRI = " + statIri);
 
         // 5. Check statement every ten seconds (a bit too frantic, but okay for this test). If status changes:
         // report new status. If status is an error (INVALID, REJECTED, FAILED) or ARCHIVED: exit.
-        Common.trackDeposit(http, statIri);
+        Common.trackDeposit(http, statIri.toURI());
     }
 
 }

--- a/src/main/resources/examples/example-bag-with-fetch/metadata/dataset.xml
+++ b/src/main/resources/examples/example-bag-with-fetch/metadata/dataset.xml
@@ -1,13 +1,10 @@
 <ddm:DDM
-	xmlns:dc="http://purl.org/dc/elements/1.1/"
-	xmlns:dcmitype="http://purl.org/dc/dcmitype/"
-	xmlns:narcis="http://easy.dans.knaw.nl/schemas/vocab/narcis-type/"
-	xmlns:dcx="http://easy.dans.knaw.nl/schemas/dcx/"
-	xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/"
-	xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
-	xmlns:dcterms="http://purl.org/dc/terms/"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/">
+        xmlns:dc="http://purl.org/dc/elements/1.1/"
+        xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/"
+        xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
+        xmlns:dcterms="http://purl.org/dc/terms/"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/">
 	<ddm:profile>
         <dc:title>The title of the Dataset</dc:title>
         <dcterms:description>The Dataset abstract</dcterms:description>

--- a/src/main/resources/examples/example-bag/metadata/dataset.xml
+++ b/src/main/resources/examples/example-bag/metadata/dataset.xml
@@ -1,13 +1,10 @@
 <ddm:DDM
-	xmlns:dc="http://purl.org/dc/elements/1.1/"
-	xmlns:dcmitype="http://purl.org/dc/dcmitype/"
-	xmlns:narcis="http://easy.dans.knaw.nl/schemas/vocab/narcis-type/"
-	xmlns:dcx="http://easy.dans.knaw.nl/schemas/dcx/"
-	xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/"
-	xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
-	xmlns:dcterms="http://purl.org/dc/terms/"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/">
+        xmlns:dc="http://purl.org/dc/elements/1.1/"
+        xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/"
+        xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
+        xmlns:dcterms="http://purl.org/dc/terms/"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/">
 	<ddm:profile>
         <dc:title>The title of the Dataset</dc:title>
         <dcterms:description>The Dataset abstract</dcterms:description>


### PR DESCRIPTION
Fixes EASY-1130
#### When applied it will
- Replace the code that used XPath to retrieve information from the deposit receipt and statement with code that uses [Apache Abdera](https://cwiki.apache.org/confluence/display/ABDERA/Creating+and+Consuming+Atom+Documents) 
#### Where should the reviewer @DANS-KNAW/easy start?

Some place where Abdera is used, for example:
https://github.com/DANS-KNAW/easy-sword2-dans-examples/compare/master...janvanmansum:EASY-1130?expand=1#diff-9f2c5221b830f5da12154e6b07b6afd5R70
#### How should this be manually tested?

Run the examples.
