### PR TITLE
NO JIRA. Helper run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ bag directories should be passed each representing a revision of the dataset, e.
 Instead of unarchiving the `tar.gz` file, you may choose to run the example programs from the command line in the maven project. Open a command line in the root
 of the maven project and then type the following (for `SimpleDeposit`): 
 
+    mvn clean install # Only necessary if the code was not previously built.
     ./run.sh Simple https://act.easy.dans.knaw.nl/sword2/collection/1 myuser mypassword src/main/resources/examples/medium
     
 This will execute the helperscript `run.sh` which uses a Maven plug-in to run the program using the artifacts in the `target` directory.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ To change the bag or make your own bags see [this wiki page].
 ### SimpleDeposit.java
 
 To run the `SimpleDeposit` example, execute the following command, of course after filling in the username and password of your SWORD-enabled
-EASY-account. For example:
+EASY-account (instead of "myuser" and "mypassword"). For example:
 
     java -cp bin/easy-sword2-dans-examples.jar nl.knaw.dans.easy.sword2examples.SimpleDeposit \
         https://act.easy.dans.knaw.nl/sword2/collection/1 myuser mypassword src/main/resources/examples/medium
@@ -115,10 +115,12 @@ bag directories should be passed each representing a revision of the dataset, e.
 Instead of unarchiving the `tar.gz` file, you may choose to run the example programs from the command line in the maven project. Open a command line in the root
 of the maven project and then type the following (for `SimpleDeposit`): 
 
-    mvn clean install
-    mvn dependency:copy-dependencies
-    java -cp "target/dependency/*:target/easy-sword2-dans-examples-1.1.0-SNAPSHOT.jar" nl.knaw.dans.easy.sword2examples.SimpleDeposit \
-       https://act.easy.dans.knaw.nl/sword2/collection/1 myuser mypassword src/main/resources/examples/medium
+    ./run.sh Simple https://act.easy.dans.knaw.nl/sword2/collection/1 myuser mypassword src/main/resources/examples/medium
+    
+This will execute the helperscript `run.sh` which uses a Maven plug-in to run the program using the artifacts in the `target` directory.
+You can select a different example program by replacing `Simple` with `Continued`, `SequenceSimple`, etc. The examples that use 
+continued depositing require an extra argument, the chunk size, before the bag directory, for example:
 
-(**NOTE**: make the version in the jar file name is the same as the version of the project)
-
+    ./run.sh Continued https://act.easy.dans.knaw.nl/sword2/collection/1 myuser mypassword 512000 src/main/resources/examples/medium
+    
+For the `SequenceXxx`-examples, the sequence of bags to deposit is the variable number of arguments at the end of the argument list.    

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2016-17 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Helper script to perform a deposit using the Maven project.
+#
+#
+
+PROGRAM=$1
+COL_IRI=$2
+USER=$3
+PASSWORD=$4
+JARFILE=$(ls -1 target/*SNAPSHOT.jar)
+
+if [[ "$PROGRAM" =~ ^.*Continued$ ]]; then
+    CHUNKSIZE=$5
+    BAGDIRS=${@:6}
+else
+    CHUNKSIZE=""
+    BAGDIRS=${@:5}
+fi
+
+mvn dependency:copy-dependencies
+java -cp "target/dependency/*:$JARFILE" "nl.knaw.dans.easy.sword2examples.${PROGRAM}Deposit" $COL_IRI $USER $PASSWORD $CHUNKSIZE $BAGDIRS
+


### PR DESCRIPTION
Adds a helper script, called `run.sh` to run the project using the Maven `exec` plugin. See updated README.md for details (last section).

@DANS-KNAW/easy 