### PR TITLE
NO JIRA. Add support for X-Authorization header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 /.vagrant/
 /.yum-repo
 /.dans.knaw.nl-yum-repo
+/x-auth-value.txt
 *.retry
 
 # Eclipse

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Getting started
 The following is a step-by-step instruction on how to run a simple example using the DANS acceptance test server at https://demo.easy.dans.knaw.nl/. 
 
 ### Getting access to the acceptance server
-1. From your account manager at DANS request access to the acceptance test server. The account manager will provide the information necessary to connect.
+1. From your account manager at DANS request access to the acceptance test server. The account manager will provide the information necessary to connect. If this
+   information includes a value for the `X-Authorization` header, then create a file called `x-auth-value.txt` in the root of this project and put the value
+   in it.
 2. Create an EASY account via https://demo.easy.dans.knaw.nl/ui/register.
 3. From your account manager at DANS request the account to be enabled for SWORD deposits.
 4. From your account manager at DANS inquire which flow (see next section) the account is configured for.

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,16 @@
                     <target>1.7</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>${license-maven-plugin.version}</version>
+                <configuration>
+                    <excludes combine.children="append">
+                        <exclude>x-auth-value.txt</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/main/java/nl/knaw/dans/easy/sword2examples/Common.java
+++ b/src/main/java/nl/knaw/dans/easy/sword2examples/Common.java
@@ -205,7 +205,7 @@ public class Common {
                 .setEntity(new ByteArrayEntity(chunk, ContentType.create(mimeType))) //
                 .build();
         addXAuthorizationToRequest(request);
-        CloseableHttpResponse response = http.execute(request);
+        CloseableHttpResponse response = http.execute(addXAuthorizationToRequest(request));
         // System.out.println("Response received.");
         return response;
     }

--- a/src/main/java/nl/knaw/dans/easy/sword2examples/Common.java
+++ b/src/main/java/nl/knaw/dans/easy/sword2examples/Common.java
@@ -66,7 +66,7 @@ public class Common {
 
     /**
      * Assumes the entity is UTF-8 encoded text and reads it into a String.
-     * 
+     *
      * @param entity
      *        the http entity object
      * @return the entire http entity as a string
@@ -93,7 +93,7 @@ public class Common {
         while (true) {
             Thread.sleep(10000);
             System.out.print("Checking deposit status ... ");
-            response = http.execute(new HttpGet(statUri));
+            response = http.execute(addXAuthorizationToRequest(new HttpGet(statUri)));
             if (response.getStatusLine().getStatusCode() != 200) {
                 System.out.println("Stat-IRI returned " + response.getStatusLine().getStatusCode());
                 System.exit(1);
@@ -194,19 +194,28 @@ public class Common {
         byte[] chunk = readChunk(dis, size);
         String md5 = new String(Hex.encodeHex(dis.getMessageDigest().digest()));
         HttpUriRequest request = RequestBuilder.create(method).setUri(uri).setConfig(RequestConfig.custom()
-        /*
-         * When using an HTTPS-connection EXPECT-CONTINUE must be enabled, otherwise buffer overflow may follow
-         */
-        .setExpectContinueEnabled(true).build()) //
+            /*
+             * When using an HTTPS-connection EXPECT-CONTINUE must be enabled, otherwise buffer overflow may follow
+             */
+            .setExpectContinueEnabled(true).build()) //
                 .addHeader("Content-Disposition", String.format("attachment; filename=%s", filename)) //
                 .addHeader("Content-MD5", md5) //
                 .addHeader("Packaging", BAGIT_URI) //
                 .addHeader("In-Progress", Boolean.toString(inProgress)) //
                 .setEntity(new ByteArrayEntity(chunk, ContentType.create(mimeType))) //
                 .build();
+        addXAuthorizationToRequest(request);
         CloseableHttpResponse response = http.execute(request);
         // System.out.println("Response received.");
         return response;
+    }
+
+    private static HttpUriRequest addXAuthorizationToRequest(HttpUriRequest request) throws Exception {
+        File autValueFile = new File("x-auth-value.txt");
+        if (autValueFile.exists()) {
+            request.addHeader("X-Authorization", FileUtils.readFileToString(autValueFile).trim());
+        }
+        return request;
     }
 
     public static void setBagIsVersionOf(File bagDir, URI versionOfUri) throws Exception {

--- a/src/main/java/nl/knaw/dans/easy/sword2examples/Common.java
+++ b/src/main/java/nl/knaw/dans/easy/sword2examples/Common.java
@@ -204,7 +204,6 @@ public class Common {
                 .addHeader("In-Progress", Boolean.toString(inProgress)) //
                 .setEntity(new ByteArrayEntity(chunk, ContentType.create(mimeType))) //
                 .build();
-        addXAuthorizationToRequest(request);
         CloseableHttpResponse response = http.execute(addXAuthorizationToRequest(request));
         // System.out.println("Response received.");
         return response;


### PR DESCRIPTION
#### When applied it will
* Add the contents of the file x-auth-value.txt as the X-Authorization header to each request

#### Where should the reviewer @DANS-KNAW/easy start?
The function `addXAuthorizationToRequest`

#### How should this be manually tested?
* Create a file called `x-auth-value.txt` in the root of your checked out clone (it is in .gitignore so you will not commit it)
* Put the X-Authorization value used for non-whitelisted access in it.
* Do a run of the examples while not inside the DANS network.

