### PR TITLE
EASY-1945: upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,11 @@
     <name>EASY SWORD2 DANS Examples</name>
     <version>1.1.0-SNAPSHOT</version>
     <inceptionYear>2016</inceptionYear>
+    <properties>
+        <httpclient.version>4.5.11</httpclient.version>
+        <abdera-parser.version>1.1.3</abdera-parser.version>
+        <bagit.version>4.12.3</bagit.version>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>commons-codec</groupId>
@@ -40,17 +45,17 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.11</version>
+            <version>${httpclient.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.abdera</groupId>
             <artifactId>abdera-parser</artifactId>
-            <version>1.1.3</version>
+            <version>${abdera-parser.version}</version>
         </dependency>
         <dependency>
             <groupId>gov.loc</groupId>
             <artifactId>bagit</artifactId>
-            <version>4.12.3</version>
+            <version>${bagit.version}</version>
         </dependency>
         <dependency>
             <groupId>net.lingala.zip4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5</version>
+            <version>4.5.11</version>
         </dependency>
         <dependency>
             <groupId>org.apache.abdera</groupId>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>gov.loc</groupId>
             <artifactId>bagit</artifactId>
-            <version>4.11.0</version>
+            <version>4.12.3</version>
         </dependency>
         <dependency>
             <groupId>net.lingala.zip4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-java-project</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1</version>
     </parent>
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>easy-sword2-dans-examples</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-java-project</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
     </parent>
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>easy-sword2-dans-examples</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-java-project</artifactId>
-        <version>5.1.0</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>easy-sword2-dans-examples</artifactId>

--- a/src/main/java/nl/knaw/dans/easy/sword2examples/Common.java
+++ b/src/main/java/nl/knaw/dans/easy/sword2examples/Common.java
@@ -20,7 +20,7 @@ import gov.loc.repository.bagit.BagFactory;
 import gov.loc.repository.bagit.BagInfoTxt;
 import gov.loc.repository.bagit.transformer.impl.TagManifestCompleter;
 import gov.loc.repository.bagit.writer.impl.FileSystemWriter;
-import net.lingala.zip4j.core.ZipFile;
+import net.lingala.zip4j.ZipFile;
 import net.lingala.zip4j.model.ZipParameters;
 import org.apache.abdera.Abdera;
 import org.apache.abdera.i18n.iri.IRI;
@@ -232,7 +232,6 @@ public class Common {
         if (zipFile.exists())
             zipFile.delete();
         ZipFile zf = new ZipFile(zipFile);
-        zf.setFileNameCharset(StandardCharsets.UTF_8.name());
         ZipParameters parameters = new ZipParameters();
         zf.addFolder(dir, parameters);
     }


### PR DESCRIPTION
Fixes EASY-1945

#### When applied it will
* upgrade parent POM version
* remove self-contained dependency version tags
* move unique dependency versions that aren't included in a parent POM to properties
* remove ZipFile setFilenameCharset UTF8, since it is already the default value

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink)